### PR TITLE
feat: expose github link on footer

### DIFF
--- a/src/lib/icons/GitHubIcon.svelte
+++ b/src/lib/icons/GitHubIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	const { size = '16' } = $props();
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	width={size}
+	height={size}
+	viewBox="0 0 24 24"
+	fill="none"
+	stroke="currentColor"
+	stroke-width="2"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+>
+	<path
+		d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"
+	/>
+</svg>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,6 +15,7 @@
 	import { FileDropEventManager } from '$lib/FileDropEventManager';
 	import Bars3 from '$lib/icons/Bars3.svelte';
 	import Copy from '$lib/icons/Copy.svelte';
+	import GitHubIcon from '$lib/icons/GitHubIcon.svelte';
 	import MagicWand from '$lib/icons/MagicWand.svelte';
 	import PanelBottom from '$lib/icons/PanelBottom.svelte';
 	import PanelLeft from '$lib/icons/PanelLeft.svelte';
@@ -428,6 +429,15 @@ LIMIT 100;`;
 			{#if BUILD}
 				<span class="label">build-{BUILD}</span>
 			{/if}
+			<a
+				href="https://github.com/agnosticeng/agx"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="github-link"
+				title="Open on GitHub"
+			>
+				<GitHubIcon size="10" />
+			</a>
 			<button
 				class:active={bottomPanel.open}
 				onclick={() => (bottomPanel.open = !bottomPanel.open)}
@@ -567,6 +577,20 @@ LIMIT 100;`;
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
+		}
+
+		& > .github-link {
+			height: 100%;
+			aspect-ratio: 1;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			color: inherit;
+
+			&:hover {
+				color: hsl(204deg 88% 65%);
+				background-color: hsl(0deg 0% 10%);
+			}
 		}
 
 		& > button {


### PR DESCRIPTION
Once I opened the AGX app in my browser, I had to return to LinkedIn or Google to find the repository again. To nudge/encourage the community to use this tool and collaborate on the repository, I suggest adding a small repo's Github link in the footer. wdyt ?

![image](https://github.com/user-attachments/assets/ef7db9a5-d437-49aa-922c-0beb0eff88f7)
